### PR TITLE
Add Angular Copilot instructions and VSCode settings for testing

### DIFF
--- a/demos/06-testing/jasmine-testing/.angular.copilot.instatuctions.md
+++ b/demos/06-testing/jasmine-testing/.angular.copilot.instatuctions.md
@@ -1,0 +1,1 @@
+When writing unit tests for Angular components that use input or input.required, you can use `fixture.componentRef.setInput()` to set the values of the inputs.

--- a/demos/06-testing/jasmine-testing/.vscode/settings.json
+++ b/demos/06-testing/jasmine-testing/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "github.copilot.chat.experimental.codeGeneration.instructions": [
+        {
+            "file": ".angular.copilot.instatuctions.md"
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces instructions for using Angular Copilot when writing unit tests for Angular components, specifically detailing how to set input values using `fixture.componentRef.setInput()`. Additionally, it includes VSCode settings to enable code generation instructions for Copilot, enhancing the development experience.